### PR TITLE
php 8 deprecated warning fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "ext-curl": "*"
+        "php": ">=5.4",
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^5"

--- a/src/IPPanel/HTTPClient.php
+++ b/src/IPPanel/HTTPClient.php
@@ -86,7 +86,7 @@ class HTTPClient
      * @throws Errors\Error
      */
     public function request(
-        $method = "GET",
+        $method,
         $url,
         $data = null,
         $params = null,


### PR DESCRIPTION
in PHP 8 using optional parameter before required parameter is deprecated and will be remove in future, this PR fixes following php 8 warnings:
`Required parameter $url follows optional parameter $method`